### PR TITLE
Add an option to configure concurrent transfers for async requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,24 @@ smartling_status: {
 }
 ```
 
+#### options.concurrentTransfers
+Type: `Integer`
+Default value: `10`
+
+When `concurrentTransfers` is provided, it will limit the number of current transfers to the provided number. This is useful to avoid hitting Smartling's API limits by requesting too many files at a time.
+
+```js
+smartling_get: {
+  options: {
+    smartling: { ... }
+    concurrentTransfers: 5
+  },
+  default: {
+    src: 'path/to/translations/*.json'
+  }
+}
+```
+
 ### Usage Examples
 
 See Gruntfile.js for usage examples

--- a/tasks/config_defaults.js
+++ b/tasks/config_defaults.js
@@ -1,0 +1,3 @@
+module.exports = {
+  concurrentTransfers: 10
+}

--- a/tasks/config_defaults.js
+++ b/tasks/config_defaults.js
@@ -1,3 +1,3 @@
 module.exports = {
   concurrentTransfers: 10
-}
+};

--- a/tasks/smartling_delete.js
+++ b/tasks/smartling_delete.js
@@ -11,17 +11,19 @@
 'use strict';
 
 module.exports = function (grunt) {
-  var asyncUtil    = require('async'),
-      SmartlingTask = require('../lib/smartling-task'),
-      DeleteStats  = require('../lib/delete-stats');
+  var asyncUtil      = require('async'),
+      SmartlingTask  = require('../lib/smartling-task'),
+      DeleteStats    = require('../lib/delete-stats'),
+      configDefaults = require('./config_defaults');
 
   grunt.registerMultiTask('smartling_delete', 'Delete files from Smartling',
     SmartlingTask.make(function (task, options, sdk, done, logJson) {
       var stats = new DeleteStats();
+      var concurrentTransfers = options.concurrentTransfers || configDefaults.concurrentTransfers;
 
       var fileUris = task.getFileUris();
 
-      asyncUtil.eachLimit(fileUris, 10, function (fileUri, callback) {
+      asyncUtil.eachLimit(fileUris, concurrentTransfers, function (fileUri, callback) {
         sdk.delete(fileUri)
           .then(function () {
             //file deleted successfully

--- a/tasks/smartling_get.js
+++ b/tasks/smartling_get.js
@@ -11,16 +11,19 @@
 'use strict';
 
 module.exports = function (grunt) {
-  var SmartlingTask = require('../lib/smartling-task'),
-      asyncUtil    = require('async'),
-      _            = require('lodash'),
-      path         = require('path'),
-      GetStats     = require('../lib/get-stats');
+  var SmartlingTask  = require('../lib/smartling-task'),
+      asyncUtil      = require('async'),
+      _              = require('lodash'),
+      path           = require('path'),
+      GetStats       = require('../lib/get-stats'),
+      configDefaults = require('./config_defaults');
+
 
   grunt.registerMultiTask('smartling_get', 'Get files from Smartling',
     SmartlingTask.make(function (task, options, sdk, done, logJson) {
       var stats = new GetStats();
       var outputDirectory = options.dest;
+      var concurrentTransfers = options.concurrentTransfers || configDefaults.concurrentTransfers;
 
       var fileUris = task.getFileUris();
       var destFileUriFunc = options.destFileUriFunc || function(fileUri) {
@@ -44,7 +47,7 @@ module.exports = function (grunt) {
       }
 
       asyncUtil.each(locales, function(locale, localeCallback) {
-        asyncUtil.eachLimit(fileUris, 10, function (fileUri, fileCallback) {
+        asyncUtil.eachLimit(fileUris, concurrentTransfers, function (fileUri, fileCallback) {
             var destFilepath;
             if (outputDirectory) {
               //check to modufy the destination fileUri

--- a/tasks/smartling_rename.js
+++ b/tasks/smartling_rename.js
@@ -11,18 +11,20 @@
 'use strict';
 
 module.exports = function (grunt) {
-  var SmartlingTask = require('../lib/smartling-task'),
-      asyncUtil    = require('async'),
-      path         = require('path'),
-      RenameStats     = require('../lib/rename-stats');
+  var SmartlingTask  = require('../lib/smartling-task'),
+      asyncUtil      = require('async'),
+      path           = require('path'),
+      RenameStats    = require('../lib/rename-stats'),
+      configDefaults = require('./config_defaults');
 
   grunt.registerMultiTask('smartling_rename', 'Rename files in Smartling',
     SmartlingTask.make(function (task, options, sdk, done, logJson) {
       var stats = new RenameStats();
+      var concurrentTransfers = options.concurrentTransfers || configDefaults.concurrentTransfers;
 
       var fileUris = task.getFileUris();
 
-      asyncUtil.eachLimit(fileUris, 10,
+      asyncUtil.eachLimit(fileUris, concurrentTransfers,
         function (fileUri, callback) {
           var newFileUri = options.newFileUriFunc(fileUri);
 

--- a/tasks/smartling_status.js
+++ b/tasks/smartling_status.js
@@ -11,17 +11,19 @@
 'use strict';
 
 module.exports = function (grunt) {
-  var asyncUtil    = require('async'),
-      SmartlingTask = require('../lib/smartling-task'),
-      StatusStats  = require('../lib/status-stats');
+  var asyncUtil      = require('async'),
+      SmartlingTask  = require('../lib/smartling-task'),
+      StatusStats    = require('../lib/status-stats'),
+      configDefaults = require('./config_defaults');
 
   grunt.registerMultiTask('smartling_status', 'Get status of files in Smartling',
     SmartlingTask.make(function (task, options, sdk, done, logJson) {
       var stats = new StatusStats();
+      var concurrentTransfers = options.concurrentTransfers || configDefaults.concurrentTransfers;
 
       var fileUris = task.getFileUris();
 
-      asyncUtil.eachLimit(fileUris, 10, function(fileUri, callback) {
+      asyncUtil.eachLimit(fileUris, concurrentTransfers, function(fileUri, callback) {
         sdk.status(fileUri, options.operation.locale)
           .then(function(statusInfo) {
             if (options.verbose) {

--- a/tasks/smartling_upload.js
+++ b/tasks/smartling_upload.js
@@ -11,19 +11,21 @@
 'use strict';
 
 module.exports = function (grunt) {
-  var asyncUtil    = require('async'),
-      SmartlingTask = require('../lib/smartling-task'),
-      UploadStats  = require('../lib/upload-stats');
+  var asyncUtil      = require('async'),
+      SmartlingTask  = require('../lib/smartling-task'),
+      UploadStats    = require('../lib/upload-stats'),
+      configDefaults = require('./config_defaults');
 
   grunt.registerMultiTask('smartling_upload', 'Upload files to Smartling',
     SmartlingTask.make(function (task, options, sdk, done, logJson) {
       var stats = new UploadStats();
+      var concurrentTransfers = options.concurrentTransfers || configDefaults.concurrentTransfers;
 
       if (task.files) {
         task.files.forEach(function (file) {
           //logJson(file);
 
-          asyncUtil.eachLimit(file.src, 10, function (filepath, callback) {
+          asyncUtil.eachLimit(file.src, concurrentTransfers, function (filepath, callback) {
             var fileUri = options.fileUriFunc(filepath);
 
             sdk.upload(filepath, fileUri, options.operation.fileType, options.operation)


### PR DESCRIPTION
Smartling only allows 50 concurrent transfers and I found that the async default in this grunt task (10) causes the API to hit the limit. I’ve found changing it to 5 fixes it, but this will allow the user to customize that number.
